### PR TITLE
fixed SLAM by reducing travel distance for SLAM update

### DIFF
--- a/src/brobot_navigation/config/slam.yaml
+++ b/src/brobot_navigation/config/slam.yaml
@@ -38,7 +38,7 @@ slam_toolbox:
     # General Parameters
     use_scan_matching: true
     use_scan_barycenter: true
-    minimum_travel_distance: 0.5
+    minimum_travel_distance: 0.1
     minimum_travel_heading: 0.5
     scan_buffer_size: 10
     scan_buffer_maximum_scan_distance: 10.0


### PR DESCRIPTION
# Description

Fixes Issue with SLAM where SLAM_TOOLBOX wouldn't snap the lidar to the map in RVIZ when translating the robot - only was doing loop closure on rotation. Decreased minimum distance. Tested on real robot

Fixes #34 

## Type of change

- [ ] Documentation Update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update






