### PR TITLE
fix: Milestone 3:  revive RPi4 version of  ballbot

### DIFF
--- a/setup_robot.sh
+++ b/setup_robot.sh
@@ -1,32 +1,69 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 WORKSPACE_DIR=$(pwd)
 IGNORED_SUFFIXES=("_viz" "_gazebo" "_simulation")
 IGNORED_DIR=".ignored_pkgs"
 
-# install rplidar ros2 drivers
-sudo apt install -y ros-$ROS_DISTRO-rplidar-ros
-# Check if rplidar.rules already exists in /etc/udev/rules.d/
+if [ -z "${ROS_DISTRO:-}" ]; then
+    echo "ERROR: ROS_DISTRO is not set. Source your ROS install first:" >&2
+    echo "  source /opt/ros/humble/setup.bash" >&2
+    exit 1
+fi
+
+if [ ! -d src ]; then
+    echo "ERROR: no src/ directory here. Run this from the workspace root." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------- rplidar
+
+echo "=== Installing rplidar driver ==="
+sudo apt install -y "ros-$ROS_DISTRO-rplidar-ros"
+
 if [ ! -f /etc/udev/rules.d/rplidar.rules ]; then
-    cd /tmp
-    wget https://raw.githubusercontent.com/allenh1/rplidar_ros/ros2/scripts/rplidar.rules
-    sudo cp rplidar.rules /etc/udev/rules.d/
-    cd "$WORKSPACE_DIR"
+    echo "=== Installing rplidar udev rules ==="
+    (
+        cd /tmp
+        wget https://raw.githubusercontent.com/allenh1/rplidar_ros/ros2/scripts/rplidar.rules
+        sudo cp rplidar.rules /etc/udev/rules.d/
+    )
+    sudo udevadm control --reload-rules && sudo udevadm trigger
 else
     echo "rplidar.rules already exists. Skipping download and copy."
 fi
 
+# ------------------------------------------------- move out sim/viz pkgs
+
+restore_pkgs() {
+    [ -d "$IGNORED_DIR" ] || return 0
+    echo ""
+    echo "=== Restoring simulation/visualization packages ==="
+    for suffix in "${IGNORED_SUFFIXES[@]}"; do
+        for dir in "$IGNORED_DIR"/*"$suffix"; do
+            [ -d "$dir" ] || continue
+            echo "Restoring $(basename "$dir")"
+            mv "$dir" src/
+        done
+    done
+    # rmdir, not rm -rf: if something unexpected is left behind, say so
+    rmdir "$IGNORED_DIR" 2>/dev/null || \
+        echo "NOTE: $IGNORED_DIR not empty, left in place — check contents."
+}
+
 echo "=== Temporarily moving out simulation/visualization packages ==="
 mkdir -p "$IGNORED_DIR"
 
+# Restore on ANY exit: success, set -e abort, or Ctrl-C.
+trap restore_pkgs EXIT
+
 for dir in src/*; do
     pkg_name=$(basename "$dir")
-    if [[ -d "$dir" ]]; then
+    # require package.xml — a dir without one is debris, not a package
+    if [[ -d "$dir" && -f "$dir/package.xml" ]]; then
         for suffix in "${IGNORED_SUFFIXES[@]}"; do
             if [[ "$pkg_name" == *"$suffix" ]]; then
                 echo "Ignoring and moving $pkg_name"
-                touch "$dir/COLCON_IGNORE"
                 mv "$dir" "$IGNORED_DIR/"
                 break
             fi
@@ -34,41 +71,53 @@ for dir in src/*; do
     fi
 done
 
-# Download and install micro-ROS
+# ---------------------------------------------------------------- micro-ROS
+
 echo "=== Cloning micro_ros_setup if needed ==="
 if [ ! -d "src/micro_ros_setup" ]; then
-    git clone -b $ROS_DISTRO https://github.com/micro-ROS/micro_ros_setup src/micro_ros_setup
+    git clone -b "$ROS_DISTRO" https://github.com/micro-ROS/micro_ros_setup src/micro_ros_setup
 else
     echo "src/micro_ros_setup already exists. Skipping clone."
 fi
 
+# ---------------------------------------------------------------- deps
+
 echo "=== Installing required build tools ==="
-sudo apt install python3-vcstool build-essential
+sudo apt install -y python3-vcstool build-essential
 
 echo "=== Running rosdep for hardware-only packages ==="
-sudo apt update && rosdep update
+sudo apt update
+rosdep update
+
+# Skipped keys, and why:
+#   microxrcedds_agent / micro_ros_agent — built from source below, not apt
 rosdep install --from-path src --ignore-src -y \
     --skip-keys microxrcedds_agent \
     --skip-keys micro_ros_agent
 
-echo "=== Building workspace (hardware-only packages) ==="
-colcon build
-source install/setup.bash
+# ---------------------------------------------------------------- build
 
-echo "=== Setting up micro-ROS agent ==="
+echo "=== Building workspace (hardware-only packages) ==="
+colcon build --symlink-install
+set +u; source install/setup.bash; set -u
+
+echo "=== Setting up micro-ROS agent (this takes a while) ==="
 ros2 run micro_ros_setup create_agent_ws.sh
 ros2 run micro_ros_setup build_agent.sh
-source install/setup.bash
+set +u; source install/setup.bash; set -u
 
-echo "=== Restoring simulation/visualization packages ==="
-for suffix in "${IGNORED_SUFFIXES[@]}"; do
-    for dir in "$IGNORED_DIR"/*"$suffix"; do
-        [ -d "$dir" ] || continue
-        echo "Restoring $(basename "$dir")"
-        mv "$dir" src/
-    done
-done
+# ---------------------------------------------------------------- verify
+
+echo "=== Verifying micro_ros_agent ==="
+if ros2 pkg executables micro_ros_agent 2>/dev/null | grep -q micro_ros_agent; then
+    echo "OK: micro_ros_agent built."
+else
+    echo "WARNING: micro_ros_agent not found — bringup will fail." >&2
+fi
 
 echo ""
-echo "To use the ROS 2 environment in this terminal, run:"
+echo "Done. To use the ROS 2 environment in this terminal, run:"
 echo "  source install/setup.bash"
+echo ""
+echo "Then:"
+echo "  ros2 launch ballbot_bringup bringup.launch.py"

--- a/src/ballbot_description/onshape/ballbot_generated/additional.xml
+++ b/src/ballbot_description/onshape/ballbot_generated/additional.xml
@@ -29,13 +29,13 @@
 
     <num_wheel_pairs>2</num_wheel_pairs>
     
-    <left_joint>front_left_wheel_joint_speed</left_joint>
-    <right_joint>front_right_wheel_joint_speed</right_joint>
+    <left_joint>front_left_wheel_joint</left_joint>
+    <right_joint>front_right_wheel_joint</right_joint>
     <wheel_separation>0.16</wheel_separation>
     <wheel_diameter>0.066</wheel_diameter>
     
-    <left_joint>rear_left_wheel_joint_speed</left_joint>
-    <right_joint>rear_right_wheel_joint_speed</right_joint>
+    <left_joint>rear_left_wheel_joint</left_joint>
+    <right_joint>rear_right_wheel_joint</right_joint>
     <wheel_separation>0.16</wheel_separation>
     <wheel_diameter>0.066</wheel_diameter>
     

--- a/src/ballbot_description/onshape/ballbot_generated/config.json
+++ b/src/ballbot_description/onshape/ballbot_generated/config.json
@@ -28,6 +28,8 @@
         "echo 'Step 2: Fixing mesh paths and saving final URDF...'",
         "mkdir -p ../urdf",
         "python fix_ros_mesh_paths.py ballbot_generated/robot.urdf ../urdf/ballbot.urdf ballbot_description meshes",
+        "echo 'Step 2b: Renaming *_joint_speed -> *_joint (getting rid of onshape-to-robot convention)...'",
+        "sed -i -E 's/_joint_speed([\"<])/_joint\\1/g' ../urdf/ballbot.urdf",
         "echo 'Step 3: Copying meshes to final location...'",
         "mkdir -p ../meshes",
         "[ -d ballbot_generated/assets/merged ] && mkdir -p ../meshes/merged",

--- a/src/ballbot_description/package.xml
+++ b/src/ballbot_description/package.xml
@@ -13,7 +13,6 @@
     <exec_depend>robot_state_publisher</exec_depend>
     <exec_depend>xacro</exec_depend>
     <!-- for gazebo plugins -->
-    <exec_depend>gazebo_ros</exec_depend>
     <export>
         <build_type>ament_cmake</build_type>
         <gazebo_ros gazebo_model_path="${prefix}/share"/>

--- a/src/ballbot_description/urdf/ballbot.urdf
+++ b/src/ballbot_description/urdf/ballbot.urdf
@@ -1440,7 +1440,7 @@
     </visual>
   </link>
   <!-- Joint from still_chassis_assm to wheel_assm -->
-  <joint name="front_left_wheel_joint_speed" type="continuous">
+  <joint name="front_left_wheel_joint" type="continuous">
     <origin xyz="0.0680211 0.0783859 -0.0305" rpy="-1.5708 -1.4446e-29 9.71445e-17"/>
     <parent link="still_chassis_assm"/>
     <child link="wheel_assm"/>
@@ -1512,7 +1512,7 @@
     </visual>
   </link>
   <!-- Joint from still_chassis_assm to wheel_assm_2 -->
-  <joint name="front_right_wheel_joint_speed" type="continuous">
+  <joint name="front_right_wheel_joint" type="continuous">
     <origin xyz="0.0680211 -0.0776141 -0.0305" rpy="-1.5708 -1.53772 -1.03884e-14"/>
     <parent link="still_chassis_assm"/>
     <child link="wheel_assm_2"/>
@@ -1584,7 +1584,7 @@
     </visual>
   </link>
   <!-- Joint from still_chassis_assm to wheel_assm_3 -->
-  <joint name="rear_left_wheel_joint_speed" type="continuous">
+  <joint name="rear_left_wheel_joint" type="continuous">
     <origin xyz="-0.0804789 0.0783859 -0.0305" rpy="-1.5708 1.5708 0"/>
     <parent link="still_chassis_assm"/>
     <child link="wheel_assm_3"/>
@@ -1656,7 +1656,7 @@
     </visual>
   </link>
   <!-- Joint from still_chassis_assm to wheel_assm_4 -->
-  <joint name="rear_right_wheel_joint_speed" type="continuous">
+  <joint name="rear_right_wheel_joint" type="continuous">
     <origin xyz="-0.0804789 -0.0776141 -0.0305" rpy="-1.5708 -1.53772 3.02617e-15"/>
     <parent link="still_chassis_assm"/>
     <child link="wheel_assm_4"/>
@@ -1802,12 +1802,12 @@
         <argument>odom:=odom/unfiltered</argument>
       </ros>
       <num_wheel_pairs>2</num_wheel_pairs>
-      <left_joint>front_left_wheel_joint_speed</left_joint>
-      <right_joint>front_right_wheel_joint_speed</right_joint>
+      <left_joint>front_left_wheel_joint</left_joint>
+      <right_joint>front_right_wheel_joint</right_joint>
       <wheel_separation>0.16</wheel_separation>
       <wheel_diameter>0.066</wheel_diameter>
-      <left_joint>rear_left_wheel_joint_speed</left_joint>
-      <right_joint>rear_right_wheel_joint_speed</right_joint>
+      <left_joint>rear_left_wheel_joint</left_joint>
+      <right_joint>rear_right_wheel_joint</right_joint>
       <wheel_separation>0.16</wheel_separation>
       <wheel_diameter>0.066</wheel_diameter>
       <!-- calculated for stall torque of 4.8 kg*cm  -->

--- a/src/ballbot_gazebo/package.xml
+++ b/src/ballbot_gazebo/package.xml
@@ -10,6 +10,7 @@
     <url type="bugtracker">https://github.com/atticusrussell/ballbot/issues</url>
     <buildtool_depend>ament_cmake</buildtool_depend>
     <buildtool_depend>ament_cmake_python</buildtool_depend>
+    <exec_depend>gazebo_ros</exec_depend>
     <exec_depend>gazebo_ros_pkgs</exec_depend>
     <exec_depend>rclpy</exec_depend>
     <exec_depend>geometry_msgs</exec_depend>

--- a/src/ros2.repos
+++ b/src/ros2.repos
@@ -1,6 +1,2 @@
 repositories: {}
-## EXAMPLE DEPENDENCY
-#   <some_ros_package>:
-#     type: git
-#     url: git@github.com:<some_github_namespace>/<some_ros_package>.git
-#     version: master
+


### PR DESCRIPTION
# Description

Brought up ballbot on the rpi4 - all sensors publishing. 

- fixed wheel joint names (removed speed suffix) so that they match what the linorobot_2 fw fork expects
- moved gazebo dependencies to the gazebo package to fix deps on real robot
- had Claude revamp the robot setup script so that it restores the sim packages even if a step fails

Fixes # (issue)
#109 

## Type of change

- [ ] Documentation Update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


tested on robot HW driving around room