### PR TITLE
docs: update roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing
+
+Working conventions for this repository. Structure lives in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md);
+sequencing lives in [`docs/ROADMAP.md`](docs/ROADMAP.md). This file covers how changes get made.
+
+---
+
+## Branching
+
+Short-lived branches off `humble`, merged and deleted. No long-lived milestone branches: navigation
+and hardware work run concurrently and both touch URDF, launch, and config files, so parallel
+long-running branches would spend more time on conflicts than on work.
+
+**A branch covers one unit of work.** Usually that is one issue. Group several when they edit the same
+file or only make sense together — a costmap tuning pass is one branch, not four.
+
+**Naming: `<track>/<slug>`**, lowercase, using the track IDs from the roadmap.
+
+```
+nav/annotate-nav2-params
+nav/amcl-and-costmap-tuning
+hw/jetson-workspace-build
+det/synthetic-capture-pipeline
+bt/v0-drive-and-return
+```
+
+Track prefixes rather than issue numbers: branches stay readable without a lookup, survive issue
+renumbering, and group under `git branch --list 'nav/*'`. Reference issues in the pull request body
+with `Closes #N` instead.
+
+**Skip the branch entirely** for reading issues, documentation typos, and deleting stale artifacts.
+Close the issue and push to `humble`.
+
+---
+
+## Merging
+
+| Change | Merge style | Why |
+|---|---|---|
+| Code, config, docs | Squash | One issue, one commit on the trunk |
+| Tuning campaigns | Merge commit | The commit sequence is the record — "inflation radius 0.3 → 0.55, and what changed" is the point |
+
+Squashing a tuning branch destroys the only durable trace of what was tried. Keep those commits.
+
+---
+
+## Tagging
+
+Tag `humble` when a milestone closes, using the lowercased track ID:
+
+```
+git tag nav-2-complete && git push origin nav-2-complete
+```
+
+Tagging is independent of branching — a milestone boundary does not require a milestone branch.
+
+---
+
+## Issues and milestones
+
+- Every milestone has a GitHub Milestone named with its track ID, e.g. `NAV-2 — Real Nav`.
+- Issues within a milestone are ordered. Work is pulled from the top rather than chosen.
+- Reading issues carry the `theory` label **and** the milestone whose work they unblock. They are
+  never label-only: reading detached from the work it serves has no natural stopping point.
+- Off-roadmap work carries `side-quest` and no milestone. Pull from there between commitments —
+  [open side-quests](https://github.com/atticusrussell/ballbot/issues?q=is%3Aopen+is%3Aissue+label%3Aside-quest).
+
+---
+
+## Documentation
+
+Three documents, deliberately non-overlapping, so that no change requires editing two of them:
+
+| Document | Holds | Changes when |
+|---|---|---|
+| `docs/ARCHITECTURE.md` | Node graph, TF tree, topic contracts, package layout, open questions, decision log | The system's structure changes |
+| `docs/ROADMAP.md` | Track structure, dependency edges, goals, exit criteria, reading | A sequencing decision is made |
+| `CONTRIBUTING.md` | Branching, merging, tagging, issue conventions | A process decision is made |
+
+Neither `ARCHITECTURE.md` nor `ROADMAP.md` carries work status or issue enumerations — GitHub holds
+those, so doing work never obliges a documentation edit.
+
+`ARCHITECTURE.md` does not reference milestone IDs; sequencing belongs to the roadmap. Its decision log
+is the exception, being a dated historical record rather than a live reference.
+
+**Architectural decisions get a dated line in the decision log**, with the reason. An open question
+moves out of the open-questions section when it is decided, and the rationale goes to the log.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The original v1 platform paired a Raspberry Pi 4 with a Teensy 4.1 (motor/encode
 
 **Status**: v2 in active development. See:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system design, node graph, TF tree, open architectural questions
-- [`docs/ROADMAP.md`](docs/ROADMAP.md) — milestone breakdown
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) — tracks, dependency graph, milestone goals, reading
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — branching, merging, tagging, issue conventions
 - [GitHub Project: Ballbot](https://github.com/users/atticusrussell/projects/6) — live progress
 
 ## Hardware

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,9 +45,9 @@ flowchart LR
 
 ---
 
-## 2. Node graph + per-phase deltas
+## 2. Node graph
 
-### Baseline (current state, post-revival)
+### Baseline — current robot
 
 ```mermaid
 flowchart LR
@@ -62,11 +62,11 @@ flowchart LR
     cam[v4l2_camera] -->|/camera/image_raw| balltrack[ball_tracker<br/>color-blob, legacy]
 ```
 
-### Adds in M1A/M1B (sim + real nav)
+### Navigation
 
-No new nodes — just tuning + map. nav2 + AMCL come up reliably.
+No new nodes. Navigation is configuration, mapping, and tuning over the baseline above.
 
-### Adds in M2A/M2B (detector)
+### Ball detection
 
 ```mermaid
 flowchart LR
@@ -77,9 +77,9 @@ flowchart LR
 
 `detection_projector` lifts 2D pixel detections to 3D poses on the floor plane using known camera extrinsics (no depth cam needed for a ball known to be ground-level).
 
-`ball_tracker` (legacy) stays alongside as a fallback / tuning aid; new BT consumes from `pickleball_detector`.
+`ball_tracker` (legacy) stays alongside as a fallback / tuning aid; the behavior tree consumes from `pickleball_detector`.
 
-### Adds in M3A/M3B (visual odometry + court)
+### Visual odometry + court keep-out
 
 ```mermaid
 flowchart LR
@@ -92,7 +92,7 @@ flowchart LR
 
 VO output is fused into the existing EKF as a pose-correction source (loose coupling). The court polygon is published as a static-layer costmap filter — nav2 plans around it natively.
 
-### Adds in M4A/M4B (manipulation)
+### Manipulation
 
 ```mermaid
 flowchart LR
@@ -102,15 +102,15 @@ flowchart LR
     detector -.feature target.-> servo
 ```
 
-### Adds in M5 (final integration)
+### Final integration
 
-No new nodes — BT v3 reaches its full form, ties everything together.
+No new nodes. The behavior tree reaches its full form and ties the subsystems together.
 
 ---
 
 ## 3. TF frame tree
 
-Target tree after v2 design (M0 deliverable). New frames in **bold**.
+Target tree for v2. New frames in **bold**.
 
 ```
 map
@@ -134,7 +134,7 @@ Notes:
 - `map` → `odom` published by AMCL (indoor) or by VO fusion (outdoor at court).
 - `odom` → `base_link` published by `ekf_filter_node`.
 - Static transforms for sensor mountings live in URDF.
-- `eye_in_hand_camera_link` calibration to `gripper_link` is hand-eye calibration (Phase 4).
+- `eye_in_hand_camera_link` calibration to `gripper_link` is hand-eye calibration.
 
 ---
 
@@ -158,9 +158,9 @@ DDS profile remains FastDDS with the custom XML at `ballbot_base/config/fastrtps
 
 ## 5. Behavior Tree decomposition
 
-Each phase ends with a BT extension. The BT lives in a new package (suggested: `ballbot_behavior`) and uses `nav2_behavior_tree` for action plumbing.
+The BT lives in its own package, `ballbot_behavior`, and uses `nav2_behavior_tree` for action plumbing. Each capability extends it by one stage.
 
-### BT v0 — end of M1B
+### BT v0 — drive and return
 "Drive to a point and come home."
 
 ```mermaid
@@ -169,7 +169,7 @@ flowchart TD
     root --> nav2[NavToPose<br/>target=base_pose]
 ```
 
-### BT v1 — end of M2B
+### BT v1 — fetch a ball
 
 "Find a ball and drive to it; come home."
 
@@ -181,7 +181,7 @@ flowchart TD
     root --> nav2[NavToPose<br/>target=base_pose]
 ```
 
-### BT v2 — end of M3B
+### BT v2 — respect the court boundary
 
 "Same, but only fetch balls outside the court polygon."
 
@@ -196,7 +196,7 @@ flowchart TD
 
 The keep-out is enforced two ways: (a) **at the planner**, via the static-layer costmap filter — robot physically can't enter the court area; and (b) **at the BT**, via `FilterBallsOutsideCourt` — robot doesn't even *try* to fetch balls that are on the court. Defense in depth.
 
-### BT v3 — end of M4B
+### BT v3 — grasp and deliver
 
 "Pick up the ball and drop it at base."
 
@@ -211,7 +211,7 @@ flowchart TD
     root --> drop[DropBall]
 ```
 
-Failure handling (retry, timeout, give-up) added as decorators in M5.
+Failure handling (retry, timeout, give-up) is added as decorators at final integration.
 
 ---
 
@@ -256,20 +256,19 @@ flowchart TB
 
 ## 7. Package layout (target)
 
-| Package | Role | Status |
+| Package | Role | State |
 |---|---|---|
-| `ballbot_description` | URDF, meshes, onshape-to-robot pipeline | major rework in **M0.1** (resurrect catbot_description CAD pipeline + simplified collisions); v2 design changes in M0.2 |
-| `ballbot_base` | Base driver config (linorobot2 fork), EKF, twist_mux | exists, minimal v2 changes |
-| `ballbot_bringup` | Launch files for real + sim | exists, extended per phase |
-| `ballbot_gazebo` | Sim worlds, plugins | exists, new pickleball court world in M3A; may absorb `obstacles.world` from `archive/catbot_simulation` |
-| `ballbot_navigation` | nav2 + AMCL config + maps | exists, retuned in M1A/M1B |
-| `ballbot_vision` | Detector node + dataset tools | exists, gains YOLO + TensorRT in M2 |
-| `ballbot_perception` (new) | Court line detection, VO, court polygon publisher | M3A |
-| `ballbot_manipulation` (new) | Visual servoing, arm action server, grasp | M4A |
-| `ballbot_behavior` (new) | Behavior tree XMLs + custom BT nodes | M1B onward |
-| `ball_tracker` (legacy) | Color-blob detector | retained as fallback / tuning aid |
-| `archive/catbot_description` | Onshape-to-robot pipeline + CAD-derived URDF | **source material for M0.1 migration**; archive can be deleted after merge |
-| `archive/catbot_simulation` | Older standalone Gazebo launch + `obstacles.world` | source for `obstacles.world` only; rest superseded by `ballbot_gazebo` |
+| `ballbot_description` | URDF, meshes, onshape-to-robot pipeline | exists |
+| `ballbot_base` | Base driver config (linorobot2 fork), EKF, twist_mux | exists |
+| `ballbot_bringup` | Launch files for real + sim | exists |
+| `ballbot_gazebo` | Sim worlds, plugins | exists; gains a pickleball court world |
+| `ballbot_navigation` | nav2 + AMCL config + maps | exists |
+| `ballbot_vision` | Detector node + dataset tools | exists; gains YOLO + TensorRT |
+| `ballbot_viz` | RViz configs and visualization helpers | exists |
+| `ballbot_perception` | Court line detection, VO, court polygon publisher | new |
+| `ballbot_manipulation` | Visual servoing, arm action server, grasp | new |
+| `ballbot_behavior` | Behavior tree XMLs + custom BT nodes | new |
+| `ball_tracker` | Color-blob detector | legacy; retained as fallback / tuning aid |
 
 ---
 
@@ -278,18 +277,18 @@ flowchart TB
 These are explicit unresolved decisions. Each will move out of this section as it's decided (with rationale captured wherever the decision lives in the doc).
 
 1. **Depth camera — yes or no, where?** Skip in v2 per current plan; mono visual servoing for manipulation. Add only if mono stalls. If added, **mounts on the arm (eye-in-hand)**, not chassis — chassis depth gives marginal nav benefit, eye-in-hand depth massively simplifies grasp. CAD: leave clearance + mounting holes on the arm; URDF: leave a `depth_camera_link` frame defined with zero mass placeholder. *Status: tentatively no, eye-in-hand if added.*
-2. **Visual servoing — IBVS or PBVS?** IBVS = simpler, image-space loop closure, robust to camera calibration error, doesn't need explicit 3D pose estimate. PBVS = explicit 3D loop, easier to integrate with motion planning. Decide before M4A. *Status: open.*
-3. **nav2 controller — DWB or MPPI?** MPPI is newer, smoother, samples thousands of trajectory rollouts. With Orin Nano Super's compute, MPPI is no longer compute-prohibitive. DWB is the safer-tested default. Decide during M1A. *Status: open, leaning MPPI.*
+2. **Visual servoing — IBVS or PBVS?** IBVS = simpler, image-space loop closure, robust to camera calibration error, doesn't need explicit 3D pose estimate. PBVS = explicit 3D loop, easier to integrate with motion planning. Decide before simulated manipulation begins. *Status: open.*
+3. **nav2 controller — DWB or MPPI?** MPPI is newer, smoother, samples thousands of trajectory rollouts. With Orin Nano Super's compute, MPPI is no longer compute-prohibitive. DWB is the safer-tested default. Decide during nav tuning. *Status: open, leaning MPPI.*
 4. **VO + AMCL fusion strategy** — Fuse VO always (loose EKF coupling), or switch on/off based on environment (indoor=AMCL, outdoor=VO)? Loose fusion is simpler; switching is more correct but adds state. *Status: tentatively loose fusion always.*
 5. ~~**Compute topology — single Jetson or distributed?**~~ **CLOSED**: single Jetson Orin Nano Super. 67 INT8 TOPS comfortably handles nav + inference + servoing simultaneously. Distributed remains a fun side experiment, not a requirement.
-6. **Detector replacement** — Does the new YOLO detector replace `ball_tracker` entirely, or live alongside? Currently planned alongside (legacy as fallback / tuning aid). Revisit after M2B confidence. *Status: alongside.*
+6. **Detector replacement** — Does the new YOLO detector replace `ball_tracker` entirely, or live alongside? Currently planned alongside (legacy as fallback / tuning aid). Revisit once the real detector is proven. *Status: alongside.*
 7. **Eye-in-hand camera type** — DOFBOT-SE ships with a USB camera + bracket. Orin Nano Super CSI port is available and supports rpicam3. USB is simpler / arm-supplied; CSI gives lower latency + better quality. *Status: tentatively use the supplied USB cam to start, swap if quality drives a need.*
 8. **Map storage strategy** — Single static apartment map, or session-rebuilt? Pickleball court geometry is *known*, so the court "map" is just the published polygon, not a SLAM map. Indoor map is static (saved). *Status: indoor static, outdoor geometric.*
 9. **Search behavior between fetches** — How does the robot wait for a ball to come into view? Options: (a) park at a chosen vantage point, chassis cam pointed at court; (b) low-rate patrol along the sideline; (c) park + active pan/tilt scan with a 2-DOF camera platform (see #10). Doesn't change architecture — only the BT search subtree. *Status: deferred; pick (a) park-at-corner as v1 placeholder.*
 10. **Pan/tilt camera platform** — Optional 2-DOF servo platform for the chassis camera. Battery-cheap (servos <1W) vs. driving (motors 5-20W) — could change the search strategy from patrol to park-and-scan. Would add a `pan_tilt_controller` node + `gimbal_link` TF frame *if* installed. *Status: deferred. No URDF placeholder reserved — adding the link later is a 5-minute change, no need to carry the complexity now.*
 11. **DOFBOT-Pro firmware/code reuse** — DOFBOT-Pro is a parallel SKU with same expansion board and confirmed Orin Nano Super support. **Confirmed**: Yahboom ships a complete URDF (`SystemFile_OrinNANOSUPER`) plus ROS code for this configuration. *Status: closing — submodule both `dofbot-pro` and `dofbot-se` into `third_party/`, compose the Pro URDF for the arm in v2 instead of re-CADing.*
 
-12. **STM32 bypass: direct I2C from Orin to expansion board** — DOFBOT-Pro evidence: the Orin Nano Super connects directly to the arm expansion board via 2 GPIO pins (I2C) over a ribbon cable, bypassing USB serial entirely. Trade-offs: lower latency, fewer cables, no host-portable abstraction layer. The DOFBOT-SE STM32 path remains as a fallback. *Status: investigation issue in M0.2; decision must precede M0.2 CAD work since it affects cable routing and plate cutouts.*
+12. **STM32 bypass: direct I2C from Orin to expansion board** — DOFBOT-Pro evidence: the Orin Nano Super connects directly to the arm expansion board via 2 GPIO pins (I2C) over a ribbon cable, bypassing USB serial entirely. Trade-offs: lower latency, fewer cables, no host-portable abstraction layer. The DOFBOT-SE STM32 path remains as a fallback. *Status: investigated; the outcome must be recorded in the decision log before CAD work, since it affects cable routing and plate cutouts.*
 
 ---
 
@@ -308,6 +307,9 @@ These are explicit unresolved decisions. Each will move out of this section as i
 - **2026-05-10** — `archive/catbot_description/` and `archive/catbot_simulation/` to be deleted after M0.1 merge. Git history preserves; `obstacles.world` absorbed into `ballbot_gazebo` if useful.
 - **2026-05-10** — Repo layout: `third_party/` at root for code submodules (Yahboom repos); `docs/third_party/` for documentation (datasheets, tutorials). Two separate domains.
 - **2026-05-10** — Roadmap moved to `docs/ROADMAP.md`. Refinement happens by editing that file, not by re-dumping in chat.
+- **2026-08-05** — Sequential milestone numbers replaced by track IDs (`NAV-`, `HW-`, `DET-`, `VO-`, `ARM-`, `BT-`, `DEMO`). Reason: hardware and navigation now run in parallel, so a single linear number asserted an ordering that no longer held. `ROADMAP.md` carries the dependency graph; entries above this line keep their original IDs, since a decision log records what was decided at the time.
+- **2026-08-05** — Milestone references removed from this document. Reason: sequencing belongs in `ROADMAP.md`, and duplicating it here created two places to update. Sections now describe subsystems rather than phase deltas. Decision-log entries are exempt as historical record.
+- **2026-08-05** — Behavior tree separated into its own track rather than appended to the navigation, detector, VO, and manipulation milestones. Reason: `ballbot_behavior` is its own package, and a capability milestone should close on whether the capability works, not on whether the autonomy layer has been wired to it.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,13 +71,20 @@ No new nodes. Navigation is configuration, mapping, and tuning over the baseline
 ```mermaid
 flowchart LR
     cam[/camera/image_raw/] --> detector[pickleball_detector<br/>YOLO TensorRT]
+    cam --> blob[ball_tracker<br/>colour blob]
     detector -->|/pickleball/detections<br/>vision_msgs/Detection2DArray| projector[detection_projector]
+    blob -.same contract.-> projector
     projector -->|/pickleball/poses<br/>geometry_msgs/PoseArray<br/>frame: map| bt[Behavior Tree]
+    style blob stroke-dasharray: 4 4
 ```
 
 `detection_projector` lifts 2D pixel detections to 3D poses on the floor plane using known camera extrinsics (no depth cam needed for a ball known to be ground-level).
 
-`ball_tracker` (legacy) stays alongside as a fallback / tuning aid; the behavior tree consumes from `pickleball_detector`.
+**Two detectors publish the same contract.** The behavior tree subscribes only to `/pickleball/poses` and cannot distinguish their output, so either may drive it. `pickleball_detector` (YOLO) is the production path; `ball_tracker` (colour blob) serves three purposes: an interface stand-in that lets autonomy be developed before a trained model exists, a fallback when inference is unavailable, and a tuning aid.
+
+The stand-in role is what makes an end-to-end fetch loop reachable on the current robot rather than only after the v2 build and detector training. `ball_tracker` is deliberately not deleted when YOLO lands.
+
+`ball_tracker`'s `follow_ball` node drives `/cmd_vel` directly, bypassing nav2 and `twist_mux`. That path predates this architecture and conflicts with the mux priority scheme; it is not part of the target design and should be remapped to a muxed input or retired.
 
 ### Visual odometry + court keep-out
 
@@ -144,7 +151,7 @@ Load-bearing custom topics. Standard ROS topics (`/scan`, `/odom`, `/cmd_vel`, `
 
 | Topic | Message type | Publisher | Subscribers | Notes |
 |---|---|---|---|---|
-| `/pickleball/detections` | `vision_msgs/Detection2DArray` | `pickleball_detector` | `detection_projector` | Per-frame 2D bounding boxes + confidence |
+| `/pickleball/detections` | `vision_msgs/Detection2DArray` | `pickleball_detector` **or** `ball_tracker` | `detection_projector` | Per-frame 2D bounding boxes + confidence. Exactly one publisher runs at a time |
 | `/pickleball/poses` | `geometry_msgs/PoseArray` | `detection_projector` | BT, RViz | Ball positions in `map` frame, ground-plane projected |
 | `/court/polygon` | `geometry_msgs/PolygonStamped` | `court_pose_estimator` | nav2 KeepoutFilter, BT | Court-edge polygon in `map` frame, defines keep-out |
 | `/court/pose_correction` | `geometry_msgs/PoseWithCovarianceStamped` | `court_pose_estimator` | `ekf_filter_node` | VO pose against court lines, fused into EKF |
@@ -268,7 +275,7 @@ flowchart TB
 | `ballbot_perception` | Court line detection, VO, court polygon publisher | new |
 | `ballbot_manipulation` | Visual servoing, arm action server, grasp | new |
 | `ballbot_behavior` | Behavior tree XMLs + custom BT nodes | new |
-| `ball_tracker` | Color-blob detector | legacy; retained as fallback / tuning aid |
+| `ball_tracker` | Colour-blob detector, 2D and ground-plane projection | retained: interface stand-in, fallback, tuning aid |
 
 ---
 
@@ -281,7 +288,7 @@ These are explicit unresolved decisions. Each will move out of this section as i
 3. **nav2 controller — DWB or MPPI?** MPPI is newer, smoother, samples thousands of trajectory rollouts. With Orin Nano Super's compute, MPPI is no longer compute-prohibitive. DWB is the safer-tested default. Decide during nav tuning. *Status: open, leaning MPPI.*
 4. **VO + AMCL fusion strategy** — Fuse VO always (loose EKF coupling), or switch on/off based on environment (indoor=AMCL, outdoor=VO)? Loose fusion is simpler; switching is more correct but adds state. *Status: tentatively loose fusion always.*
 5. ~~**Compute topology — single Jetson or distributed?**~~ **CLOSED**: single Jetson Orin Nano Super. 67 INT8 TOPS comfortably handles nav + inference + servoing simultaneously. Distributed remains a fun side experiment, not a requirement.
-6. **Detector replacement** — Does the new YOLO detector replace `ball_tracker` entirely, or live alongside? Currently planned alongside (legacy as fallback / tuning aid). Revisit once the real detector is proven. *Status: alongside.*
+6. ~~**Detector replacement** — Does the new YOLO detector replace `ball_tracker` entirely, or live alongside?~~ **CLOSED**: alongside, permanently. Beyond fallback and tuning aid, `ball_tracker` conforms to the detection contract and stands in for the detector during autonomy bring-up, which decouples behavior tree development from model training.
 7. **Eye-in-hand camera type** — DOFBOT-SE ships with a USB camera + bracket. Orin Nano Super CSI port is available and supports rpicam3. USB is simpler / arm-supplied; CSI gives lower latency + better quality. *Status: tentatively use the supplied USB cam to start, swap if quality drives a need.*
 8. **Map storage strategy** — Single static apartment map, or session-rebuilt? Pickleball court geometry is *known*, so the court "map" is just the published polygon, not a SLAM map. Indoor map is static (saved). *Status: indoor static, outdoor geometric.*
 9. **Search behavior between fetches** — How does the robot wait for a ball to come into view? Options: (a) park at a chosen vantage point, chassis cam pointed at court; (b) low-rate patrol along the sideline; (c) park + active pan/tilt scan with a 2-DOF camera platform (see #10). Doesn't change architecture — only the BT search subtree. *Status: deferred; pick (a) park-at-corner as v1 placeholder.*
@@ -310,6 +317,8 @@ These are explicit unresolved decisions. Each will move out of this section as i
 - **2026-08-05** — Sequential milestone numbers replaced by track IDs (`NAV-`, `HW-`, `DET-`, `VO-`, `ARM-`, `BT-`, `DEMO`). Reason: hardware and navigation now run in parallel, so a single linear number asserted an ordering that no longer held. `ROADMAP.md` carries the dependency graph; entries above this line keep their original IDs, since a decision log records what was decided at the time.
 - **2026-08-05** — Milestone references removed from this document. Reason: sequencing belongs in `ROADMAP.md`, and duplicating it here created two places to update. Sections now describe subsystems rather than phase deltas. Decision-log entries are exempt as historical record.
 - **2026-08-05** — Behavior tree separated into its own track rather than appended to the navigation, detector, VO, and manipulation milestones. Reason: `ballbot_behavior` is its own package, and a capability milestone should close on whether the capability works, not on whether the autonomy layer has been wired to it.
+- **2026-08-05** — `ball_tracker` retained permanently and promoted to interface stand-in, closing open question 6. Reason: the behavior tree consumes `/pickleball/poses` and cannot tell which detector produced them, so a colour-blob detector conforming to the contract unblocks autonomy development without waiting on the v2 build or a trained model. Behaviour trees validated against the stand-in are re-validated against YOLO when it lands.
+- **2026-08-05** — `detection_projector` treated as a port of `ball_tracker`'s existing `detect_ball_3d` node rather than new work. Reason: ground-plane projection from camera extrinsics already exists there; what is missing is the message contract and the map-frame transform.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,264 +1,356 @@
 # BallBot v2 Roadmap
 
-Milestone + issue breakdown for the v2 redesign. This is the working planning doc — refine here, don't re-dump in chat.
+Milestone structure for the v2 program: a differential-drive robot with an onboard arm that navigates
+indoors by lidar, localizes outdoors against pickleball-court geometry, detects and retrieves balls.
 
-**Companion docs**: [`ARCHITECTURE.md`](./ARCHITECTURE.md) is the source of truth for system structure. This doc is the source of truth for *what gets built when*.
-
-**Status legend**: 🟦 not started · 🟨 in progress · 🟩 done · ⬜ deferred / open
-
----
-
-## Conventions
-
-- Each milestone gets a GitHub Milestone (native).
-- Each bullet under "Issues" gets a GitHub Issue (native), tagged with the milestone.
-- Each milestone gets its own feature branch (`phase/M<id>-<slug>`), PR'd to `humble` when the milestone closes.
-- **Each milestone closure gets a git tag**: `m{id}-complete` (e.g., `m0.1-complete`, `m1a-complete`, `m4b-complete`). Tag every milestone, including prep / reading / hardware milestones, for trivial rollback to any phase boundary.
-- Reading-group issues use a checklist of chapter PDFs from `docs/third_party/dofbot-tutorials/`.
-- Behavior tree (BT) extension issues live at the end of their parent "B" milestone.
-- HW integration milestones (M*.5) are atomic and small — green-light test only.
+**Companion doc**: [`ARCHITECTURE.md`](./ARCHITECTURE.md) — source of truth for system structure.
+This doc is the source of truth for sequencing.
 
 ---
 
-## M0.1 — URDF foundation migration 🟦
-**Goal**: Resurrect `archive/catbot_description`'s onshape-to-robot pipeline into `ballbot_description` with simplified collisions. Mass-accurate v1 robot in URDF (no v2 design changes yet).
-**Branch**: `phase/M0.1-urdf-foundation`
-**Issues**:
-- Add `onshape-to-robot` pipeline to `ballbot_description` (config.json, `moveMeshes.sh`, `urdf_newlines.py`)
-- Migrate CAD-derived chassis + wheel meshes from `archive/catbot_description/meshes/`
-- Replace parametric base + wheel xacros with CAD-derived URDF macros
-- Configure sensors (camera, lidar, IMU) via the onshape-to-robot pipeline's `additional.xml` block
-- Simplify collision shapes: switch from full mesh collision to convex hull or primitive boxes (use the alternate forms already CAD'd)
-- Verify URDF spawns in Gazebo with no self-collision
-- Verify TF tree clean
-- Confirm mass + CoG match v1 robot
-- Delete `archive/catbot_description/` and `archive/catbot_simulation/` after merge (preserve `obstacles.world` first if absorbing)
-- Open PR + tag `m0.1-complete`
+## 1. Scope of this document
+
+| | Holds | Changes when |
+|---|---|---|
+| **GitHub Issues / Milestones** | Issue text, open/closed state, milestone membership | Work happens |
+| **This doc** | Track structure, dependency edges, goals, exit criteria | A sequencing decision is made |
+
+This doc carries no status markers and no issue enumerations, so progress never requires a doc edit.
+Issue-level detail lives in [GitHub Milestones](https://github.com/atticusrussell/ballbot/milestones);
+working conventions live in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ---
 
-## M0.2 — v2 CAD design changes 🟦
-**Goal**: Update Onshape doc with v2 changes (arm mount, Jetson, depth cam placeholder), bump document version, rerun import. Should be "run the script" not "rebuild the system."
-**Branch**: `phase/M0.2-v2-design`
-**Issues**:
-- **Investigate STM32 bypass: direct I2C from Orin to expansion board** (study DOFBOT-Pro firmware + URDF; decide before CAD changes since it affects cable routing + plate cutouts)
-- Compose Yahboom DOFBOT-Pro arm URDF into BallBot URDF (skip re-CADing the arm)
-- Design top plate in Onshape: arm mount + Jetson Orin Nano Super footprint + clearance for existing components
-- Add Jetson + heatsink as mass block in CAD
-- Add depth camera as suppressed part (zero density, mounting holes only)
-- Bump Onshape document version in `config.json`
-- Rerun onshape-to-robot import
-- Verify v2 URDF spawns in Gazebo, no self-collision
-- Sanity-check inertia + CoG against estimated v2 numbers
-- Open PR + tag `m0.2-complete`
+## 2. Principles
+
+1. **Milestones carry ordered issue lists.** Work is pulled from the top; selection is not part of
+   the task.
+
+2. **Dependencies are modelled as they are, not as convenient.** Where a real dependency serialises
+   the graph, it is drawn. Scope is not bent to manufacture parallelism.
+
+3. **Parallel fronts are used where they exist.** Deep work, bench work, and reading run concurrently
+   when the graph allows it.
+
+4. **Sequence by what falsifies cheapest.** Bench bringup precedes CAD, because a bench reveals cable
+   routing and connector reality before plate geometry is committed.
+
+5. **Simulator fidelity is established against real data, never assumed.** Tuning against an
+   unvalidated simulator produces parameters for a robot that does not exist.
+
+6. **Theory attaches to the milestone that consumes it.**
 
 ---
 
-## M1A — Sim Nav 🟦
-**Goal**: 48/50 random nav goals succeed in multi-room sim apartment.
-**Branch**: `phase/M1A-sim-nav`
-**Issues**:
-- Build multi-room sim world (4-5 rooms, doorways, clutter)
-- Update `ballbot_gazebo` launch to spawn v2 URDF in new world
-- Configure nav2 params yaml for v2 footprint + dynamics
-- Generate sim map via `slam_toolbox`
-- Read AMCL / particle filter background (Probabilistic Robotics ch 8 or equivalent)
-- Tune local + global costmap inflation
-- Choose controller (DWB vs MPPI) — leaning MPPI given Orin compute
-- Tune controller for v2 dynamics
-- Implement 50-random-goal benchmark script
-- Iterate tuning until ≥48/50
+## 3. Dependency graph
+
+```mermaid
+flowchart TD
+    N1["NAV-1<br/>Comprehension &amp; Repair"]
+    N2["NAV-2<br/>Real Nav"]
+    N3["NAV-3<br/>Sim Fidelity"]
+    N4["NAV-4<br/>Re-tune on v2"]
+
+    H1["HW-1<br/>Jetson Bench Bringup"]
+    H2["HW-2<br/>Arm Bench Bringup"]
+    H3["HW-3<br/>v2 CAD"]
+    H4["HW-4<br/>v2 Build &amp; Mount<br/><i>CoG locks here</i>"]
+    H5["HW-5<br/>On-Robot Arm Integration"]
+
+    D1["DET-1<br/>Sim Detector"]
+    D2["DET-2<br/>Real Detector"]
+    V1["VO-1<br/>Sim VO + Keep-Out"]
+    V2["VO-2<br/>Real VO at Court"]
+    A1["ARM-1<br/>Sim Manipulation"]
+    A2["ARM-2<br/>Real Manipulation"]
+
+    B1["BT-1<br/>Drive and return"]
+    B2["BT-2<br/>Fetch a ball"]
+    B3["BT-3<br/>Respect court keep-out"]
+    B4["BT-4<br/>Grasp and deliver"]
+
+    X["DEMO<br/>Integration + Court Demo"]
+
+    N1 --> N2 --> N3
+    H1 --> H2 --> H3 --> H4 --> H5
+
+    N2 --> N4
+    H4 --> N4
+
+    H1 --> D1
+    H3 --> D1
+    N3 --> D1
+    D1 --> D2
+    H4 --> D2
+
+    N2 --> V1
+    N3 --> V1
+    H3 --> V1
+    V1 --> V2
+    H4 --> V2
+
+    H3 --> A1
+    A1 --> A2
+    H5 --> A2
+
+    N2 --> B1
+    B1 --> B2
+    D2 --> B2
+    B2 --> B3
+    V2 --> B3
+    B3 --> B4
+    A2 --> B4
+
+    N4 --> X
+    B4 --> X
+
+    style N1 fill:#2d5a3d,stroke:#4a9,color:#fff
+    style H1 fill:#3d3d5a,stroke:#77a,color:#fff
+```
+
+NAV and HW are independent tracks, each with an unblocked entry point. NAV runs on the existing robot;
+HW-1 and HW-2 are bench work requiring neither chassis nor CAD.
+
+Simulation work downstream of HW-3 is gated on the v2 sensor and arm frames in the URDF rather than on
+the full CAD milestone. Plate cutouts and mounting hardware do not affect it, so that subset can be
+delivered early if the rest of CAD runs long.
 
 ---
 
-## M1.5 — HW Revival 🟦
-**Goal**: Existing real robot powers up, all ROS nodes green.
-**Branch**: `phase/M1.5-hw-revival`
-**Issues**:
-- Inspect robot from storage for damage
-- Test/replace battery, validate voltage rail
-- Re-flash Teensy with current `linorobot2_hardware`
-- Boot RPi 4 (interim host), restore wifi + ssh
-- Diagnose and fix the cyclonedds env var issue
-- Bringup smoke test (motors, lidar, IMU, camera all publish)
+## 4. Working the stack
+
+```mermaid
+flowchart LR
+    subgraph fronts["Three concurrent fronts"]
+        direction TB
+        DEEP["<b>Deep</b><br/>Critical-path milestone<br/><i>needs focus and the robot</i>"]
+        BENCH["<b>Bench</b><br/>Hardware track<br/><i>needs hands, not focus</i>"]
+        READ["<b>Reading</b><br/>Theory within the deep milestone<br/><i>needs neither</i>"]
+    end
+    DEEP -.blocked.-> BENCH
+    BENCH -.awaiting parts.-> READ
+    READ -.-> DEEP
+```
+
+A milestone becomes available when every inbound edge in the dependency graph is closed. When a front
+stalls — a part on order, a battery charging, a concept that has not landed — switch fronts rather than
+pushing.
 
 ---
 
-## M1B — Real Nav 🟦
-**Goal**: ≥9/10 RViz goals succeed in your real apartment.
-**Branch**: `phase/M1B-real-nav`
-**Issues**:
-- Run `slam_toolbox` in apartment, save initial map
-- Extend map to multi-room coverage
-- Configure AMCL with saved map
-- Re-tune costmaps for real RPLIDAR A1 noise
-- Run 10-goal apartment benchmark from RViz
-- Iterate until ≥9/10
-- **BT v0**: nav-to-hardcoded-pose + return-to-base + handle nav failure
-- Validate BT v0 with 5 successful cycles
+## 5. Milestones
+
+### NAV — Navigation
+
+Runs on the current robot. Per the baseline node graph in ARCHITECTURE.md, nav adds no new nodes — the
+entire track is configuration, mapping, and tuning.
+
+| ID | Goal | Exit criterion |
+|---|---|---|
+| **NAV-1** | Understand and repair the existing nav stack before tuning it | Live node graph and TF tree verified against the baseline diagrams in ARCHITECTURE.md; `navigation.yaml` annotated parameter by parameter; DDS configuration reconciled; saved maps triaged; one goal executes end to end |
+| **NAV-2** | nav2 and AMCL reliable in the apartment | ≥9/10 RViz goals succeed; bag files recorded for NAV-3 |
+| **NAV-3** | Establish simulator fidelity | Sim base dynamics, lidar noise, and IMU noise reconciled against NAV-2 bags; error bounds documented |
+| **NAV-4** | Restore nav performance after v2 changes mass distribution, footprint, and compute | ≥9/10 apartment goals post-build, running on the Orin |
+
+Localization survives the v2 upgrade unchanged — same wheelbase, encoders, IMU, and base firmware.
+Control does not: mass distribution, footprint, and control-loop timing all shift. NAV-4 absorbs that.
+
+### HW — v2 Hardware
+
+| ID | Goal | Exit criterion |
+|---|---|---|
+| **HW-1** | Jetson Orin Nano Super running the ROS workspace on a desk | All packages build; rpicam3 publishes over CSI; camera intrinsics captured |
+| **HW-2** | Arm alive on the bench, driven from the Jetson | Joints respond to ROS commands; servos calibrated; eye-in-hand camera mounted and hand-eye calibrated; commanded Cartesian pose reached |
+| **HW-3** | v2 CAD and model: top plate, arm mount, Jetson footprint, sensor placement | Vendor arm URDF composed into the BallBot URDF; v2 URDF spawns in Gazebo without self-collision; estimated inertia and CoG sane |
+| **HW-4** | Robot assembled in v2 configuration | Jetson mounted and powered; arm bolted to top plate; measured CoG checked against the HW-3 estimate |
+| **HW-5** | Arm integrated on the robot rather than the bench | Reachable workspace from the mounted position verified against URDF, including floor reach |
+
+HW-2 runs against the vendor-supplied arm URDF standalone, which is sufficient for servo calibration
+and Cartesian commands. Composing that arm into the BallBot URDF belongs to HW-3, since a v2 model that
+spawns without self-collision necessarily contains the arm.
+
+Hand-eye calibration sits in HW-2 because it relates the gripper to the eye-in-hand camera — arm-local,
+and unaffected by mounting the arm to the chassis.
+
+CoG is checked twice: estimated from CAD in HW-3, measured after assembly in HW-4. The measurement is
+what determines the scope of NAV-4.
+
+### DET — Detector
+
+| ID | Goal | Exit criterion |
+|---|---|---|
+| **DET-1** | YOLO detector trained on synthetic data | Sim camera model reconciled against real rpicam3 intrinsics; ≥90% mAP on held-out synthetic test set |
+| **DET-2** | Detector deployed on the Orin | ≥30 fps on Orin; ≥90% precision at 0.5–3 m indoors; ball detections published as ground-plane poses in the `map` frame |
+
+Synthetic training data is only useful once the simulated camera matches the physical one in both
+respects: intrinsics — field of view and distortion — come from the sensor itself in HW-1, while
+extrinsics — mount height, pitch, and optical-centre placement — are fixed by CAD in HW-3. The arm also
+enters the chassis camera's field of view, so its geometry must be present in sim before training
+frames are captured.
+
+### VO — Visual Odometry
+
+| ID | Goal | Exit criterion |
+|---|---|---|
+| **VO-1** | Court-line VO in simulation, keep-out costmap working | <10 cm pose error over 20 m sim traversal; nav2 respects the keep-out polygon |
+| **VO-2** | VO on a real court | <30 cm drift over court length; court polygon published in the `map` frame |
+
+VO is independent of the ball detector — line detection, geometry matching, and PnP share only a camera
+with it. VO-1 depends on nav because it publishes a costmap filter that nav2 must respect, and on HW-3
+because PnP recovers camera pose, which is only useful as robot pose once camera extrinsics are fixed.
+The keep-out costmap work is unaffected by either and can proceed ahead of the VO work.
+
+### ARM — Manipulation
+
+| ID | Goal | Exit criterion |
+|---|---|---|
+| **ARM-1** | Visual servoing grasp in simulation, arm mounted on the robot | ≥80% grasp success over 50 random-pose balls on the floor |
+| **ARM-2** | Real arm grasps a real pickleball | ≥80% over 50 bench attempts; grasp exposed as an action server |
+
+ARM-1 depends on HW-3 because mount geometry is central to the grasp problem, not incidental to it:
+whether the arm can reach the floor from the top plate, and what the eye-in-hand camera sees on
+approach, are both set by where the arm sits. A fixed-base result would not transfer. HW-5 verifies the
+same reach on the physical robot.
+
+### DEMO — Final Integration
+
+| ID | Goal | Exit criterion |
+|---|---|---|
+| **DEMO** | End-to-end ball retrieval at a real court | ≥3 balls retrieved; demo video captured; write-up published |
+
+### BT — Autonomy
+
+The behavior tree lives in its own package, `ballbot_behavior`, and is extended once by each capability
+track. Keeping it separate means a capability milestone closes on whether the capability works, not on
+whether the autonomy layer has been wired to it.
+
+| ID | Goal | Exit criterion |
+|---|---|---|
+| **BT-1** | Drive to a pose and come home | Nav to hardcoded pose, return to base, handle nav failure; 5 successful cycles |
+| **BT-2** | Fetch a ball | Wait for detection, select nearest ball, nav to approach pose, return; 5 successful cycles |
+| **BT-3** | Respect the court boundary | Balls inside the court polygon filtered out before selection; 3 successful cycles at the boundary |
+| **BT-4** | Grasp and deliver | Grasp on arrival, drop at base; 3 successful pickup-and-drop cycles |
+
+```mermaid
+flowchart LR
+    B1["<b>BT-1</b><br/>nav to pose<br/>+ return to base"]
+    B2["<b>BT-2</b><br/>+ detect ball<br/>+ nav to ball"]
+    B3["<b>BT-3</b><br/>+ court keep-out<br/>filtering"]
+    B4["<b>BT-4</b><br/>+ grasp<br/>+ drop at base"]
+    B1 --> B2 --> B3 --> B4
+    N2["NAV-2"] -.enables.-> B1
+    D2["DET-2"] -.enables.-> B2
+    VO2["VO-2"] -.enables.-> B3
+    A2["ARM-2"] -.enables.-> B4
+```
+
+Each stage is additive — BT-2 is BT-1 plus a detection subtree, and so on. Keep-out is enforced twice
+by design: at the planner through the nav2 costmap filter, and at the tree through ball filtering.
+
+Failure-handling decorators — retry, timeout, give-up — are added across the whole tree in DEMO.
 
 ---
 
-## Reading-A — Pre-Detector 🟦
-**Goal**: Foundational CV reading before training a detector.
-**Issues**:
-- Read DOFBOT course 07 (OpenCV course) — 18-chapter checklist
-- Read DOFBOT course 08 (AI vision basic) — 6-chapter checklist
+## 6. Theory
+
+Theory issues belong to the milestone whose work they unblock, and carry the `theory` label for
+filtering. Reading is pulled immediately before the implementation issue that consumes it, so it lands
+against something concrete, and it supplies a low-energy task when the bench and the robot are both
+unavailable.
+
+| Track | Subject |
+|---|---|
+| **NAV-1** | Linear algebra; probability and covariance; rotations and frames — quaternions, DCM, NED/ENU |
+| **NAV-2** | Kalman and extended Kalman filters; particle filters and Monte Carlo localization; pose-graph SLAM |
+| **DET-1** | Image formation and camera models; convolutional networks; OpenCV |
+| **VO-1** | Multi-view geometry and PnP; feature detection, optical flow, Hough transforms |
+| **ARM-1** | Kinematics and inverse kinematics; MoveIt2; PID and servo control |
 
 ---
 
-## M2A — Sim Detector 🟦
-**Goal**: ≥90% mAP on synthetic test set.
-**Branch**: `phase/M2A-sim-detector`
-**Issues**:
-- Spawn pickleballs in Gazebo with randomized poses
-- Implement domain randomization (lighting, court color, distractors)
-- Build auto-label image capture pipeline (1-2k images)
-- Set up YOLO training env on the RTX 3080
-- Train YOLOv8 (size: m or l, given Orin compute) on synthetic dataset
-- Eval on held-out synthetic test set, iterate to ≥90% mAP
-- Sanity-test detector node live in Gazebo
+## 7. Reading
+
+### Foundations
+
+- 3Blue1Brown — *Essence of Linear Algebra*
+- StatQuest — probability, covariance, and covariance-matrix geometry
+- Thrun, Burgard, Fox — *Probabilistic Robotics*, ch. 3–4 (Gaussian and nonparametric filters)
+
+### Localization and filtering — NAV
+
+- MATLAB Tech Talks — *Understanding Kalman Filters*
+- MATLAB Tech Talks — *Understanding Sensor Fusion and Tracking*
+- Thrun, Burgard, Fox — *Probabilistic Robotics*, ch. 8 (Monte Carlo localization)
+- Stachniss — [Mobile Robotics online training](https://www.ipb.uni-bonn.de/online-training-robotics/index.html):
+  Bayes filter through particle filter and MCL
+
+### Pose-graph SLAM — NAV
+
+`slam_toolbox` is a pose-graph SLAM system: a Karto-derived correlative scan matcher on the front end,
+feeding a pluggable least-squares backend that defaults to Ceres, with Sparse Pose Adjustment and g2o
+available as alternative solver plugins. This is a different algorithm family from the particle-filter
+material above, and is not covered by it.
+
+Start here, in order:
+
+1. Burgard, Grisetti, Stachniss — [*Graph-based SLAM in 20 Minutes*](https://www.youtube.com/watch?v=Alu59K8zvYs)
+   — orientation before committing to the tutorial paper.
+2. Grisetti, Kümmerle, Stachniss, Burgard — *A Tutorial on Graph-Based SLAM*,
+   [*IEEE Intelligent Transportation Systems Magazine*](https://doi.org/10.1109/MITS.2010.939925)
+   2(4):31–43, 2010. The canonical treatment; front-end/back-end split and least-squares error
+   minimization.
+3. Stachniss — [*Graph-based SLAM using Pose Graphs*](https://www.youtube.com/watch?v=uHbRKvD8TWg),
+   with [slides](https://www.ipb.uni-bonn.de/html/teaching/msr2-2020/sse2-05-graph-slam.pdf).
+4. Stachniss — [*Robust Least Squares for Graph-Based SLAM*](https://www.youtube.com/watch?v=z60RbiY18I8)
+   — why loop closures fail and how robust kernels handle outliers.
+5. Thrun, Burgard, Fox — *Probabilistic Robotics*, ch. 11 (GraphSLAM) — the textbook derivation.
+
+Implementation-specific, once the theory is in place:
+
+- Macenski, Jambrecic — *SLAM Toolbox: SLAM for the dynamic world*,
+  [*JOSS*](https://joss.theoj.org/papers/10.21105/joss.02783.pdf) 6(61), 2021 — the package's own
+  design paper.
+- Olson — [*Real-Time Correlative Scan Matching*](https://april.eecs.umich.edu/pdfs/olson2009icra.pdf),
+  ICRA 2009 — the front-end scan matcher lineage.
+- Konolige et al. — *Efficient Sparse Pose Adjustment for 2D Mapping*, IROS 2010 — the SPA backend that
+  Karto shipped and that `slam_toolbox` retains as a solver plugin.
+- [`slam_toolbox` README](https://github.com/SteveMacenski/slam_toolbox) — solver plugin configuration
+  and lifelong-mapping modes.
+
+### Perception — DET
+
+- Welch Labs — *Learning to See*; *Neural Networks Demystified*
+- 3Blue1Brown — *Neural Networks*, ch. 1–4
+- First Principles of Computer Vision — image formation and camera models
+- DOFBOT-SE course 07 (OpenCV) and course 08 (AI vision basics)
+
+### Multi-view geometry — VO
+
+- Hartley, Zisserman — *Multiple View Geometry*, PnP chapter
+- Szeliski — *Computer Vision: Algorithms and Applications* — features and structure from motion
+- First Principles of Computer Vision — features, optical flow, calibration, pose estimation
+- Stachniss — *Mobile Sensing and Robotics 2*
+- DOFBOT-SE course 12 — Hough lines, edges, contours, feature tracking, optical flow
+
+### Manipulation — ARM
+
+- Lynch, Park — *Modern Robotics*, book and lecture series
+- DOFBOT-Pro Orin-Super MoveIt case study, 10 chapters
+- DOFBOT-Pro Orin-Super ROS 2 URDF model chapter
+- DOFBOT-Pro course 11 — 3D arm control and inverse kinematics
+- DOFBOT-SE course 06 — basic servo control; course 09 ch. 1 — PID fundamentals
+
+### Source notes
+
+DOFBOT-SE tutorials (`docs/third_party/dofbot-se/`) are ROS 1 — useful for fundamentals, less so for
+ROS 2 specifics. DOFBOT-Pro tutorials (`docs/third_party/dofbot-pro/`) include ROS 2 native material
+under `23.For_JetsonORIN_SUPER_JetPack6.2/`, and are preferred wherever chapters overlap. Vendor source
+code lives under `third_party/`, separate from documentation.
 
 ---
 
-## M2.5 — HW Compute + Cam 🟦
-**Goal**: Jetson Orin Nano Super + rpicam3 swap, dummy inference passes.
-**Branch**: `phase/M2.5-hw-compute-cam`
-**Issues**:
-- Acquire Jetson Orin Nano Super carrier + PSU (if not ready)
-- Acquire rpicam3 (if not ready)
-- Mount Jetson on new top plate
-- Wire Jetson power (rail or independent BEC)
-- Migrate ROS workspace to Jetson, build all packages
-- Connect rpicam3 via CSI, verify libcamera + ROS image publisher
-- Smoke test: detector node runs on Jetson with live cam
+## 8. Conventions
 
----
+Track IDs are identifiers, not sequence. The dependency graph is the authority on ordering.
 
-## M2B — Real Detector 🟦
-**Goal**: ≥30fps on Orin, ≥90% precision in apartment 0.5-3m range.
-**Branch**: `phase/M2B-real-detector`
-**Issues**:
-- Capture 200-500 real pickleball photos (varied lighting)
-- Fine-tune sim-trained model on real data
-- Convert model to TensorRT
-- Deploy detector node on Orin, measure fps
-- Validate ≥90% precision in apartment
-- Implement detection_projector node (2D pixel → 3D ground-plane pose)
-- **BT v1**: detect → nav-to-ball → return
-- Validate BT v1 with 5 cycles in apartment
-
----
-
-## Reading-B — Pre-VO 🟦
-**Goal**: Line/feature/optical-flow reading before VO.
-**Issues**:
-- Read DOFBOT course 12 (ROS+OpenCV) — selected chapters checklist (Hough lines, edge, contour, feature tracking, optical flow)
-
----
-
-## M3A — Sim VO + Court Keep-Out 🟦
-**Goal**: <10cm pose error over 20m sim court traversal; keep-out costmap working.
-**Branch**: `phase/M3A-sim-vo`
-**Issues**:
-- Build sim pickleball court world (lines, fences)
-- Implement line detection node (Canny + Hough)
-- Implement court geometry matcher (detected lines → known layout)
-- Solve PnP for camera pose against court
-- Fuse VO with wheel odometry via `robot_localization` EKF
-- Validate <10cm pose error over 20m sim traversal
-- Publish court polygon as nav2 static-layer costmap (keep-out filter)
-- Verify nav2 respects keep-out in sim
-
----
-
-## M3B — Real VO at Court 🟦
-**Goal**: <30cm drift on real court; field-trip data captured.
-**Branch**: `phase/M3B-real-vo`
-**Issues**:
-- Field trip 1: record bag of camera/lidar/odom on real court
-- Run VO pipeline offline against bag, plot trajectory
-- Validate <30cm drift over court length
-- Tune line detector for real lighting/shadows
-- Field trip 2: live VO at court
-- **BT v2**: BT v1 + enforce court keep-out polygon (via `FilterBallsOutsideCourt` BT node + nav2 keepout filter)
-- Validate BT v2 with 3 cycles outside boundary
-
----
-
-## Reading-C — Pre-Manipulation 🟦
-**Goal**: Kinematics, control, MoveIt2 fundamentals before manipulation.
-
-Prefer DOFBOT-Pro Orin-Super tutorials (ROS 2 native, MoveIt2) over DOFBOT-SE (ROS 1) where chapters overlap.
-
-**Issues**:
-- Read DOFBOT-Pro `23.For_JetsonORIN_SUPER_JetPack6.2/12. MoveIt Case Study/` — full 10-chapter checklist (MoveIt2 config, IK design, trajectory planning, collision detection)
-- Read DOFBOT-Pro `23.For_JetsonORIN_SUPER_JetPack6.2/21. ROS2 basic course/21.ROS2 URDF model.pdf`
-- Read DOFBOT-SE course 06 (Basic control) — 12-chapter checklist (servo control fundamentals, hardware-level)
-- Read DOFBOT-SE course 09 (AI vision tracking, ch 1: PID basics) — single-chapter focus
-- Read DOFBOT-Pro course 11 (3D Robotic Arm Control and Inverse Kinematics) — 2-chapter checklist
-
----
-
-## M4A — Sim Manipulation (eye-in-hand mono) 🟦
-**Goal**: Sim arm grasps ball ≥80% in sim.
-**Branch**: `phase/M4A-sim-manip`
-**Issues**:
-- Add eye-in-hand camera to URDF on arm end-effector
-- Verify camera publishes in Gazebo
-- Implement visual servoing controller (IBVS or PBVS — pick + justify)
-- Configure hand-eye calibration in sim
-- Implement grasp policy (approach pose → close gripper)
-- Spawn 50 random-pose balls, log success rate
-- Iterate to ≥80%
-
----
-
-## M4.5 — HW Arm 🟦
-**Goal**: Arm physically mounted, calibrated, reachable.
-**Branch**: `phase/M4.5-hw-arm`
-**Issues**:
-- Physically mount DOFBOT-SE (or bypassed config from M0.2 decision) to top plate
-- Run servo calibration sequence
-- Verify arm joints respond to ROS commands (over USB or I2C per M0.2 decision)
-- Verify reachable workspace matches URDF
-- Mount eye-in-hand camera on arm
-- Hand-eye calibration on real arm
-- Smoke test: arm moves to commanded Cartesian pose
-
----
-
-## M4B — Real Manipulation 🟦
-**Goal**: Real arm grasps real pickleball ≥80% on bench.
-**Branch**: `phase/M4B-real-manip`
-**Issues**:
-- Re-tune visual servoing for real arm dynamics
-- Bench: 50 grasp attempts on real ball at known poses
-- Iterate to ≥80%
-- **BT v3**: BT v2 + grasp + drop at base
-- Validate BT v3 with 3 successful pickup-and-drop cycles
-
----
-
-## M5 — Final Integration + Court Demo 🟦
-**Goal**: ≥3 balls picked at real court, demo video captured.
-**Branch**: `phase/M5-court-demo`
-**Issues**:
-- Full pipeline sim test: 3-ball court demo end-to-end
-- Field trip 3: full pipeline at real court
-- Iterate on real-world failure modes
-- Capture demo video (multi-angle, edited)
-- Write project page / portfolio post
-
----
-
-## Tutorial reading sources
-
-- DOFBOT-SE tutorials (`docs/third_party/dofbot-se/`, also a vendored copy at `docs/third_party/dofbot-tutorials/`) are **ROS 1**. Useful for fundamentals (PID, OpenCV, Linux), less useful for ROS 2 specifics.
-- DOFBOT-Pro tutorials (`docs/third_party/dofbot-pro/`) include `23.For_JetsonORIN_SUPER_JetPack6.2/` with **ROS 2 native** content: MoveIt2 configuration, MoveIt2 inverse kinematics, MoveIt2 trajectory planning, ROS 2 URDF model.
-- **Reading-C (Pre-Manipulation) prefers the Pro/Orin-Super tutorials** for MoveIt2 + ROS 2 chapters, falling back to SE only for fundamentals.
-- Yahboom-provided source code (URDFs, ROS nodes) is at `third_party/dofbot-pro/` (Drive download) and `third_party/dofbot-se/` — separate from the docs.
-
-## Side-quest issues
-
-Off-roadmap fill-in work lives in GitHub issues with the `side-quest` label, no milestone, not on the project board. Pull from there when looking for a small task between phase commitments. See [open side-quests](https://github.com/atticusrussell/ballbot/issues?q=is%3Aopen+is%3Aissue+label%3Aside-quest).
+Issue, branch, and tagging conventions live in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,6 +57,7 @@ flowchart TD
     H4["HW-4<br/>v2 Build &amp; Mount<br/><i>CoG locks here</i>"]
     H5["HW-5<br/>On-Robot Arm Integration"]
 
+    D0["DET-0<br/>Stand-in Detector"]
     D1["DET-1<br/>Sim Detector"]
     D2["DET-2<br/>Real Detector"]
     V1["VO-1<br/>Sim VO + Keep-Out"]
@@ -77,6 +78,7 @@ flowchart TD
     N2 --> N4
     H4 --> N4
 
+    N1 --> D0
     H1 --> D1
     H3 --> D1
     N3 --> D1
@@ -95,17 +97,19 @@ flowchart TD
 
     N2 --> B1
     B1 --> B2
-    D2 --> B2
+    D0 --> B2
     B2 --> B3
     V2 --> B3
     B3 --> B4
     A2 --> B4
 
     N4 --> X
+    D2 --> X
     B4 --> X
 
     style N1 fill:#2d5a3d,stroke:#4a9,color:#fff
     style H1 fill:#3d3d5a,stroke:#77a,color:#fff
+    style D0 fill:#5a4a2d,stroke:#c93,color:#fff
 ```
 
 NAV and HW are independent tracks, each with an unblocked entry point. NAV runs on the existing robot;
@@ -114,6 +118,12 @@ HW-1 and HW-2 are bench work requiring neither chassis nor CAD.
 Simulation work downstream of HW-3 is gated on the v2 sensor and arm frames in the URDF rather than on
 the full CAD milestone. Plate cutouts and mounting hardware do not affect it, so that subset can be
 delivered early if the rest of CAD runs long.
+
+DET-0 exists so that autonomy is not gated on model training. The behavior tree subscribes only to
+`/pickleball/poses` and cannot tell which detector produced them, so the existing colour-blob tracker
+can drive it once it conforms to the contract. This puts a complete fetch loop within reach on the
+current robot, rather than only after the v2 build. DET-2 carries the re-validation of that tree
+against the trained detector.
 
 ---
 
@@ -179,8 +189,13 @@ what determines the scope of NAV-4.
 
 | ID | Goal | Exit criterion |
 |---|---|---|
+| **DET-0** | Existing colour-blob tracker conforms to the detection contract | `ball_tracker` publishes `/pickleball/detections` and `/pickleball/poses`; a ball at a surveyed position projects to within a documented tolerance |
 | **DET-1** | YOLO detector trained on synthetic data | Sim camera model reconciled against real rpicam3 intrinsics; ≥90% mAP on held-out synthetic test set |
-| **DET-2** | Detector deployed on the Orin | ≥30 fps on Orin; ≥90% precision at 0.5–3 m indoors; ball detections published as ground-plane poses in the `map` frame |
+| **DET-2** | Detector deployed on the Orin | ≥30 fps on Orin; ≥90% precision at 0.5–3 m indoors; behavior tree re-validated against the trained detector in place of the stand-in |
+
+`ball_tracker` is retained permanently rather than replaced. Beyond DET-0's stand-in role it remains a
+fallback when inference is unavailable and a tuning aid. Ground-plane projection already exists in its
+`detect_ball_3d` node, so `detection_projector` is a port to the message contract rather than new work.
 
 Synthetic training data is only useful once the simulated camera matches the physical one in both
 respects: intrinsics — field of view and distortion — come from the sensor itself in HW-1, while


### PR DESCRIPTION
# Description

Reorganises the roadmap around parallel tracks and brings `ARCHITECTURE.md` into line with it. Adds `CONTRIBUTING.md` for working conventions.

**Milestones and issues on GitHub have been restructured to match** — that half of the change is not visible in this diff.

## Roadmap changes

- **Track IDs replace M01–M19.** Hardware now runs parallel to navigation, so a single linear number asserted an ordering that no longer held. Tracks: `NAV`, `HW`, `DET`, `VO`, `ARM`, `BT`, `DEMO`.
- **Real nav before sim nav.** The Gazebo plugins have never been checked against the real robot, so tuning against them first is circular. Sim-nav-as-a-phase is dissolved; a new `NAV-3` establishes simulator fidelity *against* bags recorded during real nav.
- **Bench before CAD.** Jetson and arm bringup are desk work with no chassis dependency, and doing them first surfaces cable routing and connector reality before plate geometry is committed.
- **Behavior tree extracted to its own track.** It was previously a second exit criterion on four unrelated capability milestones. A capability milestone should close on whether the capability works.
- **`DET-0` added.** The behavior tree consumes `/pickleball/poses` and cannot tell which detector produced them, so the existing colour-blob tracker can drive it once it conforms to the contract. Autonomy stops being gated on model training.
- **Theory attached to the milestone it unblocks** rather than pooled into separate reading milestones.
- **Pose-graph SLAM reading added** — the backlog covered Gaussian and particle filters but nothing on the algorithm family `slam_toolbox` actually implements.

## Architecture changes

- Milestone references removed; sequencing belongs to the roadmap. Sections describe subsystems rather than phase deltas.
- Open question 6 closed: `ball_tracker` retained permanently, with a third role as interface stand-in.
- Stale `archive/` package rows dropped; `ballbot_viz` added.
- Decision-log entries added for each of the above. Pre-existing entries keep their original milestone IDs, being a historical record.

## GitHub restructuring (not in this diff)

- 12 milestones renamed, 9 created, 5 theory milestones deleted after being emptied
- 21 new issues, including the pose-graph SLAM reading and the `DET-0` contract work
- 25 theory issues relabelled and moved into the milestones they unblock
- Dependency graph rewired: bench work no longer blocked on the assembled robot, and BT v1 no longer waits on detector precision
- Every open issue is now either in a track milestone or labelled `side-quest`

## Type of change

- [x] Documentation Update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update